### PR TITLE
ci: add permissions to py-machineid and winregistry

### DIFF
--- a/.github/workflows/py-machineid.yaml
+++ b/.github/workflows/py-machineid.yaml
@@ -11,6 +11,9 @@ jobs:
   build:
     name: Release py-machineid
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/winregistry.yaml
+++ b/.github/workflows/winregistry.yaml
@@ -11,6 +11,9 @@ jobs:
   build:
     name: Release winregistry
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Updated py-machineid and winregistry workflows to include permissions for contents read and id-token write to enhance security and functionality.