### PR TITLE
fix: adjust workflow paths and bump keygen-py version

### DIFF
--- a/.github/workflows/py-machineid.yaml
+++ b/.github/workflows/py-machineid.yaml
@@ -1,4 +1,4 @@
-name: Release pymachineid
+name: Release py-machineid
 
 on:
   push:
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - conda-recipes/deps/py-machineid/*
+      - .github/workflows/py-machineid.yaml
 
 jobs:
   build:

--- a/.github/workflows/winregistry.yaml
+++ b/.github/workflows/winregistry.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - conda-recipes/deps/winregistry/*
+      - .github/workflows/winregistry.yaml
 
 jobs:
   build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keygen-py"
-version = "0.0.1.dev7"
+version = "0.0.1.dev8"
 license = "MIT"
 description = "Unofficial Keygen SDK for Python. Integrate license activation and offline licensing. Wrapper around keygen-rs rust crate"
 requires-python = ">=3.9"


### PR DESCRIPTION
Updated workflow paths in YAML files to include themselves, and renamed py-machineid workflow. Bumped keygen-py version from dev7 to dev8 in pyproject.toml.