### PR TITLE
fix: trigger publish on release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish wheels and conda packages
 
 on:
-  push:
-    tags:
-      - v*
+  release:
+    types: [created]
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keygen-py"
-version = "0.1.3"
+version = "0.1.4"
 license = "MIT"
 description = "Unofficial Keygen SDK for Python. Integrate license activation and offline licensing. Wrapper around keygen-rs rust crate"
 requires-python = ">=3.9"


### PR DESCRIPTION
Changed the GitHub Actions workflow to trigger upon release creation instead of tag pushes. This ensures that the publishing process aligns with official release versions, improving the package distribution workflow.