### PR TITLE
fix: update release trigger and bump version to 0.1.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish wheels and conda packages
 
 on:
   release:
-    types: [created]
+    types: [released]
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keygen-py"
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT"
 description = "Unofficial Keygen SDK for Python. Integrate license activation and offline licensing. Wrapper around keygen-rs rust crate"
 requires-python = ">=3.9"


### PR DESCRIPTION
Changed the GitHub Actions workflow trigger from 'created' to 'released' for more accurate release handling. Bumped the project version from 0.1.4 to 0.1.5 in preparation for the next release.