### PR TITLE
fix: use repository dispatch for releases

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -78,18 +78,13 @@ jobs:
               ]
             }
 
-      - name: Push new Tag
-        run: |
-          echo "Creating a new tag: $VERSION"
-          git config --global user.email "support@terraquantum.swiss"
-          git config --global user.name "Terra Quantum"
-          git tag $VERSION
-          git push origin $VERSION
-        env:
-          VERSION: ${{ needs.check_version.outputs.version }}
-
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.build_changelog.outputs.changelog }}
           tag_name: ${{ needs.check_version.outputs.version }}
+
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: trigger-release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish wheels and conda packages
 
 on:
-  push:
-    tags:
-      - v*
+  repository_dispatch:
+    types: [trigger-release]
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keygen-py"
-version = "0.1.6"
+version = "0.1.7"
 license = "MIT"
 description = "Unofficial Keygen SDK for Python. Integrate license activation and offline licensing. Wrapper around keygen-rs rust crate"
 requires-python = ">=3.9"


### PR DESCRIPTION
Removed the push tag step from the release workflow and replaced the trigger for the publish workflow with repository dispatch. This ensures that releases are handled more flexibly and can be triggered manually or programmatically. Also, updated the project version in pyproject.toml from 0.1.6 to 0.1.7.